### PR TITLE
Fix broken link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,4 +2,4 @@
 
 The repo https://twitter.github.io/birdwatch/ now lives in https://twitter.github.io/communitynotes/.
 
-This repository is only maintained to redirect URLs from the archived Birdwatch site (eg. https://twitter.github.io/birdwatch/), to our new site: (https://communitynotes.twitter/guide).
+This repository is only maintained to redirect URLs from the archived Birdwatch site (eg. https://twitter.github.io/birdwatch/), to our new site: (https://communitynotes.twitter.com/guide).


### PR DESCRIPTION
Linked to communitynotes.twitter, which is not a valid URL. Changed to correct communitynotes.twitter.com.